### PR TITLE
Update deploy_wml_pmml.ipynb

### DIFF
--- a/component-library/deploy/deploy_wml_pmml.ipynb
+++ b/component-library/deploy/deploy_wml_pmml.ipynb
@@ -105,7 +105,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "o = client.software_specifications.get_uid_by_name('spark-mllib_2.4')\n",
+    "o = client.software_specifications.get_uid_by_name('spark-mllib_3.0')\n",
     "software_spec_uid = o\n",
     "client.set.default_space(space)"
    ]


### PR DESCRIPTION
Changes have been made to include spark_ml_3.0 version in deploy_pmml.ipynb instead of spark_ml_2.4 as this is giving a version incompatibility issue.