### PR TITLE
docs: integrate roadmap from claimed-framework.github.io repo

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,65 @@
+# Project Roadmap
+
+CLAIMED is a framework designed to transform your code into reusable, composable
+components that can run across diverse execution environments with built-in
+scaling and fault tolerance.
+
+---
+
+## Central Project Objective
+
+- **C3 Compiler**: Develop a unified system that transforms arbitrary code into standardized, reusable AI and data components.
+- **Seamless Deployment**: Enable components to run across heterogeneous environments including Kubernetes, Docker, Slurm, LSF, and local or virtual setups.
+- **Infrastructure Abstraction**: Automate packaging, dependency resolution, and environment isolation to ensure consistent execution.
+- **Parallelization**: Facilitate grid-computing style workload distribution across available compute resources with minimal user intervention.
+- **Composability**: Promote reuse of data engineering, data science, and AI pipelines through a flexible but opinionated component ecosystem.
+
+---
+
+## Progress to Date
+
+- Established core architecture for reusable data engineering, data science, and AI components.
+- Implemented initial component registry and composition logic for modular and reproducible pipelines.
+- Integrated foundational runtime support for Docker- and Kubernetes-based execution.
+- Developed early prototypes of the C3 Compiler, converting Python and Bash workflows into self-contained components.
+- Set up continuous integration pipelines.
+- Shifted primary focus to the C3 Compiler for seamless composition, scaling, and multi-platform execution (EU funded).
+- Developed containerless execution framework to remove reliance on Docker while maintaining reproducibility (EU funded).
+
+---
+
+## Future Developments
+
+- **Dependency Minimization**: Streamline runtime to remove heavy infrastructure dependencies, improving portability and security.
+- **Scalable Execution Backends**: Expand native support for Kubernetes, Docker, Slurm, LSF, and local/virtual environments.
+- **Enhanced Developer Experience**: Simplify component creation and sharing via CLI and SDK improvements.
+- **Automated Testing**: Integrate full test coverage into CI/CD pipelines with a target of ≥80%.
+
+---
+
+## Upcoming Releases
+
+### v0.8 (Q4 2025)
+
+- Core C3 Compiler with initial composition and multi-platform execution.
+- Basic containerless execution prototype.
+- CLI enhancements and improved developer onboarding.
+
+### v0.9 (Q1 2026)
+
+- Full dependency minimization pass.
+- Expanded publishing targets (MLX, PyPI, Conda).
+- Integrated test harness with coverage reporting.
+
+### v1.0 (Mid 2026)
+
+- Stable C3 Compiler release.
+- Full-scale containerless execution support.
+- Robust component ecosystem ready for production-scale deployment.
+- Achieve ≥80% test coverage and validated reproducibility across environments.
+
+---
+
+CLAIMED empowers developers and researchers to focus on **innovation**, while
+abstracting away infrastructure complexity and enabling scalable, reproducible,
+and composable AI workflows.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -68,6 +68,7 @@ markdown_extensions:
 
 nav:
   - Home: index.md
+  - Roadmap: roadmap.md
   - Getting Started: getting-started.md
   - CLI Reference: cli.md
   - C3 – Component Compiler:


### PR DESCRIPTION
## Summary

Consolidates the unique documentation from the standalone `claimed-framework.github.io` repository into this repo's docs site, ahead of retiring that repo.

That repo contained only two things:
- An `index.html` redirect to `claimed-framework.github.io/claimed/` — the mkdocs site **already built and hosted from this repo** via the `docs.yml` workflow.
- A `README.md` **project roadmap** (objectives, progress, future developments, v0.8/v0.9/v1.0 release plan) that did not exist anywhere in this repo.

This PR migrates that roadmap so nothing is lost when the other repo is deleted.

## Changes
- Add `docs/roadmap.md` with the migrated roadmap content.
- Add a top-level **Roadmap** nav entry in `mkdocs.yml` (after Home).

## Note before deleting `claimed-framework.github.io`
The bare-domain redirect (`https://claimed-framework.github.io/` → `/claimed/`) lives in that org-pages repo. Deleting it makes the bare-domain URL 404, while `claimed-framework.github.io/claimed/` (this repo's gh-pages) keeps working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)