### PR TITLE
release: bump version to 0.5.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ version_file = "src/c3/_version.py"
 
 [project]
 name = "claimed"
-version = "0.2.7"
+version = "0.5.0"
 description = "The CLAIMED framework (now bundling terratorch-iterate)"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Bumps `pyproject.toml` to **0.5.0** ahead of cutting the GitHub Release / tag `v0.5.0`.

First release since `0.2.7`. Notable changes on `main` since then:
- terratorch-iterate merged into `claimed`
- MLX experiment-tracking integration
- per-metric optimisation direction (minimize/maximize) in `iterate2`
- versioned docs publishing via `mike`
- project roadmap consolidated into the docs site

The version jumps to `0.5.0` to cleanly clear the stale `v0.3.x`/`v0.4` tags left from earlier history.

Once merged, I'll publish a GitHub Release tagged `v0.5.0`, which triggers the PyPI publish and the versioned docs build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)