### PR TITLE
docs: fix mkdocstrings refs after terratorch-iterate merge

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -158,7 +158,7 @@ To run a benchmark over a ray cluster (which must be created before running), us
 To check the experiment results, use `mlflow ui --host $(hostname -f) --port <port> --backend-store-uri <storage_uri>` and click the link.
 ![mlflow demo](images/mlflow.png)
 
-## :::benchmark.backbone_benchmark.benchmark_backbone
+## :::terratorch_iterate.backbone_benchmark.benchmark_backbone
 
 ## Default and Task specification
 
@@ -166,15 +166,15 @@ Under each of these, as well as for the `optimization_space`, the structure of p
 
 An exception is made for `batch_size` in `optimization_space`, which should be passed in the root level and is not passed to the `terratorch_task`.
 
-### :::benchmark.benchmark_types.Defaults
+### :::terratorch_iterate.benchmark_types.Defaults
 
-### :::benchmark.benchmark_types.Task
+### :::terratorch_iterate.benchmark_types.Task
 
-## :::benchmark.benchmark_types.ParameterBounds
+## :::terratorch_iterate.benchmark_types.ParameterBounds
 
-## :::benchmark.benchmark_types.TaskTypeEnum
+## :::terratorch_iterate.benchmark_types.TaskTypeEnum
 
-## :::benchmark.benchmark_types.ParameterTypeEnum
+## :::terratorch_iterate.benchmark_types.ParameterTypeEnum
 
 ## Credits
 

--- a/docs/ray.md
+++ b/docs/ray.md
@@ -63,4 +63,4 @@ You can then use ray job to interact with your job. See [the ray quickstart guid
 
 More easily, you can use the ray dashboard and MLFlow to check your job.
 
-## :::benchmark.benchmark_ray.benchmark_backbone
+## :::terratorch_iterate.benchmark_ray.benchmark_backbone

--- a/docs/repeating_experiments.md
+++ b/docs/repeating_experiments.md
@@ -8,4 +8,4 @@ You can do this with:
 repeat_best_experiment <parent_run_id> <absolute_path_to_store_results> --config <path_to_config>
 ```
 
-## :::benchmark.repeat_best_experiment.rerun_best_from_backbone
+## :::terratorch_iterate.repeat_best_experiment.rerun_best_from_backbone


### PR DESCRIPTION
## Problem

The v0.5.0 versioned-docs deploy failed (and `mkdocs build` was failing locally too) with:

```
mkdocstrings: ... accessing 'benchmark' raises ModuleNotFoundError: No module named 'benchmark'
Could not collect 'benchmark.backbone_benchmark.benchmark_backbone'
```

The terratorch-iterate merge moved those modules from the `benchmark` package to **`terratorch_iterate`**, but the mkdocstrings `:::` directives in the docs still pointed at `benchmark.*`.

## Fix

Update all stale directives to `terratorch_iterate.*` across:
- `docs/index.md` (backbone_benchmark, benchmark_types.*)
- `docs/ray.md` (benchmark_ray.benchmark_backbone)
- `docs/repeating_experiments.md` (repeat_best_experiment.rerun_best_from_backbone)

Verified locally: `mkdocs build` now exits 0 and produces `site/index.html`.

## Follow-up
After merge, the docs workflow will re-publish `dev` cleanly. I'll also re-run the `v0.5.0` docs deploy via `workflow_dispatch` so the released version's docs build (it failed on release because of this bug).

🤖 Generated with [Claude Code](https://claude.com/claude-code)