### PR TITLE
chore: bump version to 0.6.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ version_file = "src/c3/_version.py"
 
 [project]
 name = "claimed"
-version = "0.5.0"
+version = "0.6.0"
 description = "The CLAIMED framework (now bundling terratorch-iterate)"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Bumps the package version `0.5.0` → `0.6.0` ahead of tagging the `v0.6.0` release.

This release includes:
- **#325** — database-backed job coordinator (`claimed propagate_jobs` / `claimed work_jobs`)
- **#326** — relocation of the iterate sources to `claimed.iterate` (import path `terratorch_iterate` → `claimed.iterate`)

Verified locally: `python -m build` succeeds, `twine check` passes, and the wheel ships `claimed/iterate/*`, `claimed/jobcoordinator/*`, and the updated `iterate` / `iterate-classic` entry points.

Once merged, push the `v0.6.0` tag to trigger the PyPI publish workflow.